### PR TITLE
Removed Surplus Columns From Comments/Articles

### DIFF
--- a/db/migrate/20170718182241_remove_comment_id_from_comments.rb
+++ b/db/migrate/20170718182241_remove_comment_id_from_comments.rb
@@ -1,0 +1,5 @@
+class RemoveCommentIdFromComments < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :comments, :comment_id, :integer
+  end
+end

--- a/db/migrate/20170718182325_remove_article_id_from_articles.rb
+++ b/db/migrate/20170718182325_remove_article_id_from_articles.rb
@@ -1,0 +1,5 @@
+class RemoveArticleIdFromArticles < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :articles, :article_id, :integer
+  end
+end


### PR DESCRIPTION
Entries were being auto-index so the additional id columns
were removed from the Comments and Articles tables. The following
commands were used to accomplish this task:

"bin/rails generate migration RemoveComment_IdFromComments comment_id:integer"
"bin/rails generate migration RemoveArticle_IdFromArticles article_id:integer"